### PR TITLE
Python 3.6 is not supported by GitHub anymore

### DIFF
--- a/melpazoid.yml
+++ b/melpazoid.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
-      with: { python-version: 3.6 }
+      with: { python-version: 3.11.0 }
     - name: Install
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The original workflow YAML file gave me this error: https://github.com/tinloaf/org-incoming/actions/runs/3679726954/jobs/6224516996#step:3:6

Using Python 3.11 (the most recent version available) fixes the problem.